### PR TITLE
chore: version bump 0.0.4 --> 0.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "typed-environment",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "typed-environment is a zero-dependency, TypeScript-native library to load and validate environment variables using a custom schema. Get fully typed, safe, and reliable config objects with ease.",
     "license": "MIT",
     "author": "Ashutosh Kumar",


### PR DESCRIPTION
This pull request includes a version bump for the `typed-environment` package in the `package.json` file, updating it from `0.0.4` to `0.0.5`.