### PR TITLE
chore: allow force push for ci

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,7 @@ jobs:
           NEW_VERSION=$(node -e "console.log(require('./package.json').version)")
           
           # Commit and push changes
-          git push --follow-tags origin main
+          git push --force --follow-tags origin main
           
           echo "version_bumped=true" >> $GITHUB_OUTPUT
           echo "New version: $NEW_VERSION"


### PR DESCRIPTION
This pull request modifies the `.github/workflows/publish.yml` file to adjust the behavior of the Git push command in the workflow.

Workflow improvement:

* Changed the Git push command to use the `--force` flag in addition to `--follow-tags`. This ensures that the push will overwrite any conflicting changes in the remote repository, which may be necessary for certain automated workflows. (`[.github/workflows/publish.ymlL59-R59](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L59-R59)`)